### PR TITLE
Add documentation for describe_images

### DIFF
--- a/R/Images.r
+++ b/R/Images.r
@@ -84,6 +84,7 @@ deregister_image <- function(image, ...) {
 #' @param owner \dots
 #' @template dots
 #' @return A list
+#' @seealso \url{http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html}
 #' @examples
 #' \dontrun{
 #' # RStudio AMIs from: http://www.louisaslett.com/RStudio_AMI/

--- a/man-roxygen/filter.R
+++ b/man-roxygen/filter.R
@@ -1,1 +1,1 @@
-#' @param filter \dots
+#' @param filter One or more filters can be specified by a named list or vector where the keys are the names of the list/vector items and the values are the list/vector values. Refer to the corresponding version of the AWS REST API documentation used by \link{ec2HTTP} in issuing your command for a list of available key names.


### PR DESCRIPTION
In wrangling with describe_images this morning, the following appears to be the behavior of filters in aws.ec2.  Is this correct?  Is this the correct way to add it?  Is this the correct way to contribute to cloudyr?  Thanks.