### PR TITLE
Update allocate_ip to return allocation_id

### DIFF
--- a/R/ip.R
+++ b/R/ip.R
@@ -26,12 +26,15 @@ allocate_ip <- function(domain = c("vpc", "standard"), ...) {
     if (!missing(domain)) {
         domain <- match.arg(domain)
         query$Domain <- domain
-    }
+    } 
     r <- ec2HTTP(query = query, ...)
-    if ("publicIp" %in% names(r)) {
+    if (r$domain == "standard" ) {
         out <- list(publicIp = r$publicIp[[1]], domain = r$domain[[1]])
+    } else if(r$domain == "vpc") {
+        out <- list(publicIp = r$publicIp[[1]], allocationId = r$allocationId[[1]], domain = r$domain[[1]])
     } else {
-        out <- list(allocationId = r$allocationId[[1]], domain = r$domain[[1]])
+        print("Unrecognized domain. NOT ALLOCATING ADDRESS")
+        return(NULL)
     }
     return(structure(out, 
                      class = "ec2_ip", 


### PR DESCRIPTION
Issue: In the previous code the allocation_id was not returned for an EIP allocated in VPC when calling `allocate_ip` which caused `release_ip` to fail.

Fix: Based on the documentation for [v2015-10-01](http://awsdocs.s3.amazonaws.com/EC2/2015-10-01/ec2-api-2015-10-01.pdf), attribute `domain` should be used to distinguish VPC vs standard instead of `publicIp`.

Testing: My  AWS account supports only VPC and not EC2 Classic, which is how I discovered the issue and tested the fix.

Lingering Concerns: I have not tested this with EC2 classic, I don't know how to do that. But someone should..